### PR TITLE
Add kustomize overlays for upgrade deployments

### DIFF
--- a/docker/server-docker/start-and-tail.sh
+++ b/docker/server-docker/start-and-tail.sh
@@ -25,7 +25,7 @@ then
 fi
 
 # Change ownership of the data directory needed
-chmod 750 /opt/dbmarlin/postgresql/data
+chmod 750 /opt/dbmarlin/postgresql/15/data
 
 # Run the configure script
 ./configure.sh -a -n9090 -t9080 -p9070 -sSmall -u

--- a/k8s/server2-k8s/README.md
+++ b/k8s/server2-k8s/README.md
@@ -1,0 +1,42 @@
+# DBmarlin Kubernetes upgrade starter
+
+This is a starter Kustomize layout for testing DBmarlin Server in Kubernetes with either a standard Deployment or a StatefulSet.
+
+The quickest path for a small Proxmox/kubeadm lab is:
+
+```bash
+# from this directory
+kubectl apply -k k8s/overlays/standalone-localpath
+```
+
+For the StatefulSet version:
+
+```bash
+kubectl apply -k k8s/overlays/stateful-localpath
+```
+
+## Important assumptions
+
+- The DBmarlin image contains `/dbmarlin-install/dbmarlin`.
+- DBmarlin runs from `/opt/dbmarlin`.
+- The preserved files are currently assumed to be:
+  - `/opt/dbmarlin/.htpasswd`
+  - `/opt/dbmarlin/nginx/conf/auth.conf`
+  - `/opt/dbmarlin/nginx/conf/ssl.conf`
+- The PVC is mounted at `/opt/dbmarlin`.
+- The local lab uses the `local-path` StorageClass.
+
+Adjust the preserved file paths if your image stores them elsewhere.
+
+## Suggested workflow
+
+1. Install local-path provisioner if needed.
+2. Apply one overlay.
+3. Verify DBmarlin starts.
+4. Change the image tag in the overlay patch.
+5. Re-apply the overlay to test an upgrade.
+
+```bash
+kubectl apply -k k8s/overlays/standalone-localpath
+kubectl get pods,pvc,svc
+```

--- a/k8s/server2-k8s/k8s/base/kustomization.yaml
+++ b/k8s/server2-k8s/k8s/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - pvc.yaml
+  - service.yaml

--- a/k8s/server2-k8s/k8s/base/pvc.yaml
+++ b/k8s/server2-k8s/k8s/base/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: dbmarlin-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 20Gi

--- a/k8s/server2-k8s/k8s/base/service.yaml
+++ b/k8s/server2-k8s/k8s/base/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: dbmarlin-service
+spec:
+  selector:
+    app: dbmarlin-server
+  ports:
+    - name: web
+      protocol: TCP
+      port: 9090
+      targetPort: 9090
+  type: LoadBalancer

--- a/k8s/server2-k8s/k8s/components/deployment/deployment.yaml
+++ b/k8s/server2-k8s/k8s/components/deployment/deployment.yaml
@@ -1,0 +1,81 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dbmarlin-server
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: dbmarlin-server
+  template:
+    metadata:
+      labels:
+        app: dbmarlin-server
+    spec:
+      terminationGracePeriodSeconds: 60
+      initContainers:
+        - name: dbmarlin-init
+          image: dbmarlin/dbmarlin-server:latest
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/bash
+            - /scripts/dbmarlin-upgrade-init.sh
+          volumeMounts:
+            - name: dbmarlin-storage
+              mountPath: /opt/dbmarlin
+            - name: dbmarlin-upgrade-init
+              mountPath: /scripts
+              readOnly: true
+      containers:
+        - name: dbmarlin-server
+          image: dbmarlin/dbmarlin-server:latest
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/bash
+            - -c
+          args:
+            - while true; do /opt/dbmarlin/start-and-tail.sh; done
+          ports:
+            - name: web
+              containerPort: 9090
+            - name: tomcat
+              containerPort: 9080
+            - name: postgres
+              containerPort: 9070
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - /opt/dbmarlin/stop.sh >> /opt/dbmarlin/tomcat/logs/localhost.$(date +%Y-%m-%d).log 2>&1 && sleep 10
+          resources:
+            limits:
+              cpu: "1"
+              memory: "1024Mi"
+            requests:
+              cpu: "0.5"
+              memory: "256Mi"
+          livenessProbe:
+            tcpSocket:
+              port: 9080
+            initialDelaySeconds: 60
+            periodSeconds: 30
+          readinessProbe:
+            tcpSocket:
+              port: 9080
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          volumeMounts:
+            - name: dbmarlin-storage
+              mountPath: /opt/dbmarlin
+      volumes:
+        - name: dbmarlin-storage
+          persistentVolumeClaim:
+            claimName: dbmarlin-pvc
+        - name: dbmarlin-upgrade-init
+          configMap:
+            name: dbmarlin-upgrade-init
+            defaultMode: 0755

--- a/k8s/server2-k8s/k8s/components/deployment/kustomization.yaml
+++ b/k8s/server2-k8s/k8s/components/deployment/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - deployment.yaml

--- a/k8s/server2-k8s/k8s/components/statefulset/headless-service.yaml
+++ b/k8s/server2-k8s/k8s/components/statefulset/headless-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: dbmarlin-headless
+spec:
+  clusterIP: None
+  selector:
+    app: dbmarlin-server
+  ports:
+    - name: web
+      port: 9090
+      targetPort: 9090

--- a/k8s/server2-k8s/k8s/components/statefulset/kustomization.yaml
+++ b/k8s/server2-k8s/k8s/components/statefulset/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - statefulset.yaml
+  - headless-service.yaml

--- a/k8s/server2-k8s/k8s/components/statefulset/statefulset.yaml
+++ b/k8s/server2-k8s/k8s/components/statefulset/statefulset.yaml
@@ -1,0 +1,82 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: dbmarlin-server
+spec:
+  serviceName: dbmarlin-headless
+  replicas: 1
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: dbmarlin-server
+  template:
+    metadata:
+      labels:
+        app: dbmarlin-server
+    spec:
+      terminationGracePeriodSeconds: 60
+      initContainers:
+        - name: dbmarlin-init
+          image: dbmarlin/dbmarlin-server:latest
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/bash
+            - /scripts/dbmarlin-upgrade-init.sh
+          volumeMounts:
+            - name: dbmarlin-storage
+              mountPath: /opt/dbmarlin
+            - name: dbmarlin-upgrade-init
+              mountPath: /scripts
+              readOnly: true
+      containers:
+        - name: dbmarlin-server
+          image: dbmarlin/dbmarlin-server:latest
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/bash
+            - -c
+          args:
+            - while true; do /opt/dbmarlin/start-and-tail.sh; done
+          ports:
+            - name: web
+              containerPort: 9090
+            - name: tomcat
+              containerPort: 9080
+            - name: postgres
+              containerPort: 9070
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - /opt/dbmarlin/stop.sh >> /opt/dbmarlin/tomcat/logs/localhost.$(date +%Y-%m-%d).log 2>&1 && sleep 10
+          resources:
+            limits:
+              cpu: "1"
+              memory: "1024Mi"
+            requests:
+              cpu: "0.5"
+              memory: "256Mi"
+          livenessProbe:
+            tcpSocket:
+              port: 9080
+            initialDelaySeconds: 60
+            periodSeconds: 30
+          readinessProbe:
+            tcpSocket:
+              port: 9080
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          volumeMounts:
+            - name: dbmarlin-storage
+              mountPath: /opt/dbmarlin
+      volumes:
+        - name: dbmarlin-storage
+          persistentVolumeClaim:
+            claimName: dbmarlin-pvc
+        - name: dbmarlin-upgrade-init
+          configMap:
+            name: dbmarlin-upgrade-init
+            defaultMode: 0755

--- a/k8s/server2-k8s/k8s/components/statefulset/statefulset.yaml
+++ b/k8s/server2-k8s/k8s/components/statefulset/statefulset.yaml
@@ -6,7 +6,7 @@ spec:
   serviceName: dbmarlin-headless
   replicas: 1
   updateStrategy:
-    type: RollingUpdate
+    type: OnDelete
   selector:
     matchLabels:
       app: dbmarlin-server

--- a/k8s/server2-k8s/k8s/overlays/standalone-aks/image-patch.yaml
+++ b/k8s/server2-k8s/k8s/overlays/standalone-aks/image-patch.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dbmarlin-server
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: dbmarlin-init
+          image: dbmarlin/dbmarlin-server:latest
+      containers:
+        - name: dbmarlin-server
+          image: dbmarlin/dbmarlin-server:latest

--- a/k8s/server2-k8s/k8s/overlays/standalone-aks/kustomization.yaml
+++ b/k8s/server2-k8s/k8s/overlays/standalone-aks/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+  - ../../components/deployment
+
+patches:
+  - path: storageclass-patch.yaml
+  - path: image-patch.yaml

--- a/k8s/server2-k8s/k8s/overlays/standalone-aks/storageclass-patch.yaml
+++ b/k8s/server2-k8s/k8s/overlays/standalone-aks/storageclass-patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: dbmarlin-pvc
+spec:
+  storageClassName: managed-csi

--- a/k8s/server2-k8s/k8s/overlays/standalone-eks/image-patch.yaml
+++ b/k8s/server2-k8s/k8s/overlays/standalone-eks/image-patch.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       initContainers:
         - name: dbmarlin-init
-          image: dbmarlin/dbmarlin-server:latest
+          image: dbmarlin/dbmarlin-server:5.8.0
       containers:
         - name: dbmarlin-server
-          image: dbmarlin/dbmarlin-server:latest
+          image: dbmarlin/dbmarlin-server:5.8.0

--- a/k8s/server2-k8s/k8s/overlays/standalone-eks/image-patch.yaml
+++ b/k8s/server2-k8s/k8s/overlays/standalone-eks/image-patch.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dbmarlin-server
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: dbmarlin-init
+          image: dbmarlin/dbmarlin-server:latest
+      containers:
+        - name: dbmarlin-server
+          image: dbmarlin/dbmarlin-server:latest

--- a/k8s/server2-k8s/k8s/overlays/standalone-eks/kustomization.yaml
+++ b/k8s/server2-k8s/k8s/overlays/standalone-eks/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+  - ../../components/deployment
+
+patches:
+  - path: storageclass-patch.yaml
+  - path: image-patch.yaml

--- a/k8s/server2-k8s/k8s/overlays/standalone-eks/storageclass-patch.yaml
+++ b/k8s/server2-k8s/k8s/overlays/standalone-eks/storageclass-patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: dbmarlin-pvc
+spec:
+  storageClassName: gp3

--- a/k8s/server2-k8s/k8s/overlays/standalone-gke/image-patch.yaml
+++ b/k8s/server2-k8s/k8s/overlays/standalone-gke/image-patch.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dbmarlin-server
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: dbmarlin-init
+          image: dbmarlin/dbmarlin-server:latest
+      containers:
+        - name: dbmarlin-server
+          image: dbmarlin/dbmarlin-server:latest

--- a/k8s/server2-k8s/k8s/overlays/standalone-gke/kustomization.yaml
+++ b/k8s/server2-k8s/k8s/overlays/standalone-gke/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+  - ../../components/deployment
+
+patches:
+  - path: storageclass-patch.yaml
+  - path: image-patch.yaml

--- a/k8s/server2-k8s/k8s/overlays/standalone-gke/storageclass-patch.yaml
+++ b/k8s/server2-k8s/k8s/overlays/standalone-gke/storageclass-patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: dbmarlin-pvc
+spec:
+  storageClassName: standard-rwo

--- a/k8s/server2-k8s/k8s/overlays/standalone-localpath/dbmarlin-upgrade-init.sh
+++ b/k8s/server2-k8s/k8s/overlays/standalone-localpath/dbmarlin-upgrade-init.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+echo "Starting DBmarlin upgrade init"
+
+mkdir -p /opt/dbmarlin/.preserved
+
+cp -p /opt/dbmarlin/.htpasswd /opt/dbmarlin/.preserved/ 2>/dev/null || true
+cp -p /opt/dbmarlin/auth.conf /opt/dbmarlin/.preserved/ 2>/dev/null || true
+cp -p /opt/dbmarlin/ssl.conf /opt/dbmarlin/.preserved/ 2>/dev/null || true
+
+cp -r /dbmarlin-install/dbmarlin/* /opt/dbmarlin/
+
+cp -p /opt/dbmarlin/.preserved/.htpasswd /opt/dbmarlin/ 2>/dev/null || true
+cp -p /opt/dbmarlin/.preserved/auth.conf /opt/dbmarlin/ 2>/dev/null || true
+cp -p /opt/dbmarlin/.preserved/ssl.conf /opt/dbmarlin/ 2>/dev/null || true
+
+echo "DBmarlin init complete"

--- a/k8s/server2-k8s/k8s/overlays/standalone-localpath/image-patch.yaml
+++ b/k8s/server2-k8s/k8s/overlays/standalone-localpath/image-patch.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       initContainers:
         - name: dbmarlin-init
-          image: dbmarlin/dbmarlin-server:latest
+          image: dbmarlin/dbmarlin-server:5.8.0
       containers:
         - name: dbmarlin-server
-          image: dbmarlin/dbmarlin-server:latest
+          image: dbmarlin/dbmarlin-server:5.8.0

--- a/k8s/server2-k8s/k8s/overlays/standalone-localpath/image-patch.yaml
+++ b/k8s/server2-k8s/k8s/overlays/standalone-localpath/image-patch.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dbmarlin-server
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: dbmarlin-init
+          image: dbmarlin/dbmarlin-server:latest
+      containers:
+        - name: dbmarlin-server
+          image: dbmarlin/dbmarlin-server:latest

--- a/k8s/server2-k8s/k8s/overlays/standalone-localpath/kustomization.yaml
+++ b/k8s/server2-k8s/k8s/overlays/standalone-localpath/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+components:
+  - ../../components/deployment
+
+patches:
+  - path: storageclass-patch.yaml
+  - path: image-patch.yaml
+
+configMapGenerator:
+  - name: dbmarlin-upgrade-init
+    files:
+      - dbmarlin-upgrade-init.sh
+
+generatorOptions:
+  disableNameSuffixHash: true

--- a/k8s/server2-k8s/k8s/overlays/standalone-localpath/storageclass-patch.yaml
+++ b/k8s/server2-k8s/k8s/overlays/standalone-localpath/storageclass-patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: dbmarlin-pvc
+spec:
+  storageClassName: local-path

--- a/k8s/server2-k8s/k8s/overlays/stateful-aks/image-patch.yaml
+++ b/k8s/server2-k8s/k8s/overlays/stateful-aks/image-patch.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: dbmarlin-server
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: dbmarlin-init
+          image: dbmarlin/dbmarlin-server:latest
+      containers:
+        - name: dbmarlin-server
+          image: dbmarlin/dbmarlin-server:latest

--- a/k8s/server2-k8s/k8s/overlays/stateful-aks/kustomization.yaml
+++ b/k8s/server2-k8s/k8s/overlays/stateful-aks/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+  - ../../components/statefulset
+
+patches:
+  - path: storageclass-patch.yaml
+  - path: image-patch.yaml

--- a/k8s/server2-k8s/k8s/overlays/stateful-aks/storageclass-patch.yaml
+++ b/k8s/server2-k8s/k8s/overlays/stateful-aks/storageclass-patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: dbmarlin-pvc
+spec:
+  storageClassName: managed-csi

--- a/k8s/server2-k8s/k8s/overlays/stateful-eks/image-patch.yaml
+++ b/k8s/server2-k8s/k8s/overlays/stateful-eks/image-patch.yaml
@@ -3,11 +3,33 @@ kind: StatefulSet
 metadata:
   name: dbmarlin-server
 spec:
+  serviceName: dbmarlin-server
+  replicas: 1
+
+  volumeClaimTemplates:
+  - metadata:
+      name: dbmarlin-data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      storageClassName: gp3
+      resources:
+        requests:
+          storage: 20Gi
+
+  template:
+    spec:
+      containers:
+      - name: dbmarlin-server
+        image: dbmarlin/dbmarlin-server:5.8.0
+        volumeMounts:
+        - name: dbmarlin-data
+          mountPath: /var/lib/postgresql/data
   template:
     spec:
       initContainers:
         - name: dbmarlin-init
-          image: dbmarlin/dbmarlin-server:latest
+          image: dbmarlin/dbmarlin-server:5.8.0
       containers:
         - name: dbmarlin-server
-          image: dbmarlin/dbmarlin-server:latest
+          image: dbmarlin/dbmarlin-server:5.8.0

--- a/k8s/server2-k8s/k8s/overlays/stateful-eks/image-patch.yaml
+++ b/k8s/server2-k8s/k8s/overlays/stateful-eks/image-patch.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: dbmarlin-server
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: dbmarlin-init
+          image: dbmarlin/dbmarlin-server:latest
+      containers:
+        - name: dbmarlin-server
+          image: dbmarlin/dbmarlin-server:latest

--- a/k8s/server2-k8s/k8s/overlays/stateful-eks/kustomization.yaml
+++ b/k8s/server2-k8s/k8s/overlays/stateful-eks/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+  - ../../components/statefulset
+
+patches:
+  - path: storageclass-patch.yaml
+  - path: image-patch.yaml

--- a/k8s/server2-k8s/k8s/overlays/stateful-eks/storageclass-patch.yaml
+++ b/k8s/server2-k8s/k8s/overlays/stateful-eks/storageclass-patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: dbmarlin-pvc
+spec:
+  storageClassName: gp3

--- a/k8s/server2-k8s/k8s/overlays/stateful-gke/image-patch.yaml
+++ b/k8s/server2-k8s/k8s/overlays/stateful-gke/image-patch.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: dbmarlin-server
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: dbmarlin-init
+          image: dbmarlin/dbmarlin-server:latest
+      containers:
+        - name: dbmarlin-server
+          image: dbmarlin/dbmarlin-server:latest

--- a/k8s/server2-k8s/k8s/overlays/stateful-gke/kustomization.yaml
+++ b/k8s/server2-k8s/k8s/overlays/stateful-gke/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+  - ../../components/statefulset
+
+patches:
+  - path: storageclass-patch.yaml
+  - path: image-patch.yaml

--- a/k8s/server2-k8s/k8s/overlays/stateful-gke/storageclass-patch.yaml
+++ b/k8s/server2-k8s/k8s/overlays/stateful-gke/storageclass-patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: dbmarlin-pvc
+spec:
+  storageClassName: standard-rwo

--- a/k8s/server2-k8s/k8s/overlays/stateful-localpath/dbmarlin-upgrade-init.sh
+++ b/k8s/server2-k8s/k8s/overlays/stateful-localpath/dbmarlin-upgrade-init.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+echo "Starting DBmarlin upgrade init"
+
+mkdir -p /opt/dbmarlin/.preserved
+
+cp -p /opt/dbmarlin/.htpasswd /opt/dbmarlin/.preserved/ 2>/dev/null || true
+cp -p /opt/dbmarlin/auth.conf /opt/dbmarlin/.preserved/ 2>/dev/null || true
+cp -p /opt/dbmarlin/ssl.conf /opt/dbmarlin/.preserved/ 2>/dev/null || true
+
+cp -r /dbmarlin-install/dbmarlin/* /opt/dbmarlin/
+
+cp -p /opt/dbmarlin/.preserved/.htpasswd /opt/dbmarlin/ 2>/dev/null || true
+cp -p /opt/dbmarlin/.preserved/auth.conf /opt/dbmarlin/ 2>/dev/null || true
+cp -p /opt/dbmarlin/.preserved/ssl.conf /opt/dbmarlin/ 2>/dev/null || true
+
+echo "DBmarlin init complete"

--- a/k8s/server2-k8s/k8s/overlays/stateful-localpath/image-patch.yaml
+++ b/k8s/server2-k8s/k8s/overlays/stateful-localpath/image-patch.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: dbmarlin-server
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: dbmarlin-init
+          image: dbmarlin/dbmarlin-server:5.8.1
+      containers:
+        - name: dbmarlin-server
+          image: dbmarlin/dbmarlin-server:5.8.1

--- a/k8s/server2-k8s/k8s/overlays/stateful-localpath/image-patch.yaml
+++ b/k8s/server2-k8s/k8s/overlays/stateful-localpath/image-patch.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       initContainers:
         - name: dbmarlin-init
-          image: dbmarlin/dbmarlin-server:5.8.1
+          image: dbmarlin/dbmarlin-server:latest
       containers:
         - name: dbmarlin-server
-          image: dbmarlin/dbmarlin-server:5.8.1
+          image: dbmarlin/dbmarlin-server:latest

--- a/k8s/server2-k8s/k8s/overlays/stateful-localpath/image-patch.yaml
+++ b/k8s/server2-k8s/k8s/overlays/stateful-localpath/image-patch.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       initContainers:
         - name: dbmarlin-init
-          image: dbmarlin/dbmarlin-server:latest
+          image: dbmarlin/dbmarlin-server:6.5.1
       containers:
         - name: dbmarlin-server
-          image: dbmarlin/dbmarlin-server:latest
+          image: dbmarlin/dbmarlin-server:6.5.1

--- a/k8s/server2-k8s/k8s/overlays/stateful-localpath/kustomization.yaml
+++ b/k8s/server2-k8s/k8s/overlays/stateful-localpath/kustomization.yaml
@@ -1,0 +1,24 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+components:
+  - ../../components/statefulset
+
+patches:
+  - path: storageclass-patch.yaml
+  - path: image-patch.yaml
+
+configMapGenerator:
+
+  - name: dbmarlin-upgrade-init
+
+    files:
+
+      - dbmarlin-upgrade-init.sh
+
+generatorOptions:
+
+  disableNameSuffixHash: true

--- a/k8s/server2-k8s/k8s/overlays/stateful-localpath/storageclass-patch.yaml
+++ b/k8s/server2-k8s/k8s/overlays/stateful-localpath/storageclass-patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: dbmarlin-pvc
+spec:
+  storageClassName: local-path

--- a/k8s/server2-k8s/scripts/create-overlays.sh
+++ b/k8s/server2-k8s/scripts/create-overlays.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_DIR="k8s/overlays"
+
+OVERLAYS=(
+  standalone-localpath
+  standalone-gke
+  standalone-aks
+  standalone-eks
+  stateful-localpath
+  stateful-gke
+  stateful-aks
+  stateful-eks
+)
+
+for overlay in "${OVERLAYS[@]}"; do
+  mkdir -p "${BASE_DIR}/${overlay}"
+
+  mode="deployment"
+  if [[ "${overlay}" == stateful-* ]]; then
+    mode="statefulset"
+  fi
+
+  storage_class="local-path"
+  if [[ "${overlay}" == *-gke ]]; then
+    storage_class="standard-rwo"
+  elif [[ "${overlay}" == *-aks ]]; then
+    storage_class="managed-csi"
+  elif [[ "${overlay}" == *-eks ]]; then
+    storage_class="gp3"
+  fi
+
+  cat > "${BASE_DIR}/${overlay}/kustomization.yaml" <<KUSTOMIZE
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+  - ../../components/${mode}
+
+patches:
+  - path: storageclass-patch.yaml
+  - path: image-patch.yaml
+KUSTOMIZE
+
+  cat > "${BASE_DIR}/${overlay}/storageclass-patch.yaml" <<PATCH
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: dbmarlin-pvc
+spec:
+  storageClassName: ${storage_class}
+PATCH
+
+  if [[ "${mode}" == "deployment" ]]; then
+    cat > "${BASE_DIR}/${overlay}/image-patch.yaml" <<PATCH
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dbmarlin-server
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: dbmarlin-init
+          image: dbmarlin/dbmarlin-server:latest
+      containers:
+        - name: dbmarlin-server
+          image: dbmarlin/dbmarlin-server:latest
+PATCH
+  else
+    cat > "${BASE_DIR}/${overlay}/image-patch.yaml" <<PATCH
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: dbmarlin-server
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: dbmarlin-init
+          image: dbmarlin/dbmarlin-server:latest
+      containers:
+        - name: dbmarlin-server
+          image: dbmarlin/dbmarlin-server:latest
+PATCH
+  fi
+
+done
+
+echo "Created DBmarlin Kustomize overlays under ${BASE_DIR}"

--- a/k8s/server2-k8s/storage/README.md
+++ b/k8s/server2-k8s/storage/README.md
@@ -1,0 +1,40 @@
+# DBmarlin Kubernetes - storage options
+
+This contains different storage options. Working with local storage to start with.
+
+```bash
+# from this directory
+kubectl apply -k k8s/overlays/standalone-localpath
+```
+
+For the StatefulSet version:
+
+```bash
+kubectl apply -k k8s/overlays/stateful-localpath
+```
+
+## Important assumptions
+
+- The DBmarlin image contains `/dbmarlin-install/dbmarlin`.
+- DBmarlin runs from `/opt/dbmarlin`.
+- The preserved files are currently assumed to be:
+  - `/opt/dbmarlin/.htpasswd`
+  - `/opt/dbmarlin/nginx/conf/auth.conf`
+  - `/opt/dbmarlin/nginx/conf/ssl.conf`
+- The PVC is mounted at `/opt/dbmarlin`.
+- The local lab uses the `local-path` StorageClass.
+
+Adjust the preserved file paths if your image stores them elsewhere.
+
+## Suggested workflow
+
+1. Install local-path provisioner if needed.
+2. Apply one overlay.
+3. Verify DBmarlin starts.
+4. Change the image tag in the overlay patch.
+5. Re-apply the overlay to test an upgrade.
+
+```bash
+kubectl apply -k k8s/overlays/standalone-localpath
+kubectl get pods,pvc,svc
+```

--- a/k8s/server2-k8s/storage/persistentvolume.yaml
+++ b/k8s/server2-k8s/storage/persistentvolume.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: local-pv-example
+spec:
+  capacity:
+    storage: 10Gi
+  volumeMode: Filesystem
+  accessModes:
+  - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: local-storage
+  local:
+    path: /opt/local-storage # The actual path on the worker node
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - k8s-worker1 # The exact name of your node
+

--- a/k8s/server2-k8s/storage/storageclass-local.yaml
+++ b/k8s/server2-k8s/storage/storageclass-local.yaml
@@ -1,0 +1,7 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: local-storage
+provisioner: kubernetes.io/no-provisioner # indicates that this StorageClass does not support automatic provisioning
+volumeBindingMode: WaitForFirstConsumer
+


### PR DESCRIPTION
This work related to Jira DBMAR-2504 "Improve functionality for installing DBmarlin infrastructure within Kubernetes Pods"

New branch created in kustomize called server2-k8s

Currently being tested in local storage, but ready to test on cloud hosted Kubernetes environments.